### PR TITLE
Fixed PHP error when 'hasIcon' is not set in the 'addToCart' block.

### DIFF
--- a/public/templates/addtocart.php
+++ b/public/templates/addtocart.php
@@ -1,6 +1,6 @@
 <p class="wp-block-advanced-gutenberg-blocks-addtocart">
   <a style="background-color: <?php echo $attributes['backgroundColor']; ?>" class="wp-block-advanced-gutenberg-blocks-addtocart__button" href="<?php echo $add_to_cart_url; ?>">
-    <?php if ( $attributes['hasIcon'] !== false ): ?>
+    <?php if ( ! isset( $attributes['hasIcon'] ) || $attributes['hasIcon'] !== false ): ?>
       <span class="dashicons dashicons-<?php echo $attributes['icon']; ?>" ></span>
     <?php endif; ?>
     <span class="wp-block-advanced-gutenberg-blocks-addtocart__label"><?php echo $attributes['label']; ?></span>


### PR DESCRIPTION
Hi!

thanks for your awesome plugin! I found a glich this PR is fixing.

When creating a new 'add to cart' button, the 'hasIcon' toggle is by default to true, but it's defined in the JS, if the toggle is not modified the value is not stored, and at this point of PHP the `$attributes['hasIcon']` does not exist, so testing it fixes a PHP notice.

thanks!