### PR TITLE
The price-currency order depending on currency type not working on add-to-cart button

### DIFF
--- a/classes/Blocks/AddToCart.php
+++ b/classes/Blocks/AddToCart.php
@@ -56,8 +56,8 @@ class AddToCart {
 		$add_to_cart_url = get_site_url() . '?add-to-cart=' . $attributes['productID'];
 
 		$currency = get_woocommerce_currency_symbol();
-		$cb = ( $currency == "$" ) ? $currency : '';
-		$ca = ( $currency != "$" ) ? $currency : '';
+		$cb = ( $currency == "&#36;" ) ? $currency : '';
+		$ca = ( $currency != "&#36;" ) ? $currency : '';
 
 		ob_start();
     include apply_filters( 'advanced_gutenberg_blocks_template', Consts::get_path() . 'public/templates/addtocart.php', 'addtocart' );


### PR DESCRIPTION
The currency-price order for the add-to-cart button is not working properly. That's due to the `get_woocommerce_currency_symbol` function which returns the htmlentity of the symbol, not the symbol itself as string. This makes the order check fail and place the currency symbol always after the price number.

This PR fixes this issue.