### PR TITLE
Do not use l10n strings as anchor name

### DIFF
--- a/admin/templates/blocks_management.php
+++ b/admin/templates/blocks_management.php
@@ -13,8 +13,8 @@
 		</h1>
 
 		<ul class="AGB-header__menu">
-			<?php foreach( $categories as $cat ): ?>
-				<li><a href="#<?php echo sanitize_title( $cat ); ?>"><?php echo $cat; ?></a></li>
+			<?php foreach( $categories as $key => $cat ): ?>
+				<li><a href="#<?php echo esc_attr( $key ); ?>"><?php echo $cat; ?></a></li>
 			<?php endforeach; ?>
 		</ul>
 
@@ -27,10 +27,10 @@
 		<?php
 			foreach( $categories as $key => $cat ):
 				// Check for WooCommerce
-				$no_woo = ( $cat == "WooCommerce" and ! class_exists( 'WooCommerce' ) );
+				$no_woo = ( $key == "woo" and ! class_exists( 'WooCommerce' ) );
 		?>
-			<div class="AGB-cards" id="list-<?php echo sanitize_title( $cat ); ?>">
-				<h2 class="AGB-cards__title" id="<?php echo sanitize_title( $cat ); ?>"> 	–– <?php echo $cat; ?></h2>
+			<div class="AGB-cards" id="list-<?php echo esc_attr( $key ); ?>">
+				<h2 class="AGB-cards__title" id="<?php echo esc_attr( $key ); ?>"> 	–– <?php echo $cat; ?></h2>
 				<?php if ( $no_woo ) : ?>
 					<p class="AGB-cards__info"><?php _e( 'WooCommerce is not activated on this website.', 'advanced-gutenberg-blocks' ); ?></p>
 				<?php endif; ?>

--- a/admin/templates/disable_blocks.php
+++ b/admin/templates/disable_blocks.php
@@ -11,8 +11,8 @@
 		</h1>
 
 		<ul class="AGB-header__menu">
-			<?php foreach( $native_blocks as $cat => $blocks ): ?>
-				<li><a href="#<?php echo sanitize_title( $cat ); ?>"><?php echo $cat; ?></a></li>
+			<?php foreach( $native_categories as $key => $cat ): ?>
+				<li><a href="#<?php echo esc_attr( $key ); ?>"><?php echo $cat; ?></a></li>
 			<?php endforeach; ?>
 		</ul>
 
@@ -23,13 +23,13 @@
 
 	<main class="AGB-main" id="AGB-main">
 		<?php
-			foreach( $native_blocks as $cat => $blocks ):
+			foreach( $native_categories as $key => $cat ):
 		?>
-			<div class="AGB-cards" id="list-<?php echo sanitize_title( $cat ); ?>">
-				<h2 class="AGB-cards__title" id="<?php echo sanitize_title( $cat ); ?>"> –– <?php echo $cat; ?></h2>
+			<div class="AGB-cards" id="list-<?php echo esc_attr( $key ); ?>">
+				<h2 class="AGB-cards__title" id="<?php echo esc_attr( $key ); ?>"> –– <?php echo $cat; ?></h2>
 				<ul class="AGB-cards__list list">
 					<?php
-						foreach( $blocks as $block ):
+						foreach( $native_blocks[$key] as $block ):
 							$active = ! in_array( $block['id'], $disabled_blocks );
 					?>
 						<li class="AGB-card<?php if ( $active ) : ?> is-active<?php endif; ?>">

--- a/classes/Services/Blocks.php
+++ b/classes/Services/Blocks.php
@@ -142,7 +142,7 @@ abstract class Blocks {
 
 	public static function get_native_blocks() {
 		return array(
-			__( 'Common', 'advanced-gutenberg-blocks' ) => array(
+			'common' => array(
 				'paragraph' => array(
 					'id' => 'core/paragraph',
 					'name' => __( 'Paragraph', 'advanced-gutenberg-blocks' ),
@@ -215,7 +215,7 @@ abstract class Blocks {
 				),
 			),
 
-			__( 'Formatting' ) => array(
+			'formatting'  => array(
 
 				'code' => array(
 					'id' => 'core/code',
@@ -261,7 +261,7 @@ abstract class Blocks {
 				),
 			),
 
-			__( 'Layout' ) => array(
+			'layout' => array(
 
 				'media-text' => array(
 					'id' => 'core/media-text',
@@ -321,7 +321,7 @@ abstract class Blocks {
 				),
 			),
 
-			__( 'Widgets' ) => array(
+			'widgets'  => array(
 
 				'social-links' => array(
 					'id' => 'core/social-links',
@@ -367,7 +367,7 @@ abstract class Blocks {
 				),
 			),
 
-			__( 'Embed' ) => array(
+			'embed' => array(
 				'embed' => array(
 					'id' => 'core/embed',
 					'name' => 'Embed',

--- a/classes/WP/Settings.php
+++ b/classes/WP/Settings.php
@@ -29,7 +29,7 @@ class Settings {
 	public function add_admin_menu() {
 
 		global $submenu;
-    
+
 		add_submenu_page(
 			Consts::PLUGIN_NAME,
 			__( 'Manage Blocks' , 'advanced-gutenberg-blocks' ),
@@ -141,6 +141,7 @@ class Settings {
 	public function disable_blocks_page() {
 
 		$native_blocks = Blocks::get_native_blocks();
+		$native_categories = Blocks::get_native_blocks_categories();
 		$disabled_blocks = Blocks::get_disabled_blocks();
 
 		require_once Consts::get_path() . 'admin/templates/disable_blocks.php';


### PR DESCRIPTION
Using translated strings as anchor names may breaks ancor jump. (Especially common in non-Latin characters such as CJK, and actually occurred in Japanese)

Also, it's not good to use translated text as a key in an associative array because it will break when a bullshit translation is passed to you.