### PR TITLE
 case sensitive import

### DIFF
--- a/src/blocks/gmap/inspect.js
+++ b/src/blocks/gmap/inspect.js
@@ -1,5 +1,5 @@
 import Geocoder from "./geocoder"
-import StyleSelector from "./styleselector"
+import StyleSelector from "./styleSelector"
 
 import { __ } from '@wordpress/i18n'
 const { Component } = wp.element


### PR DESCRIPTION
In my environment, the webpack build failed.
Because the file system I'm using is case-sensitive, but there was a case mismatch import statement.